### PR TITLE
Add support for regions other than us-west-2 in EC2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Optional Arguments:
                         Custom image arguments (default: None)
   -profile str          AWS profile name in .boto (default: laniakea)
   -max-spot-price #     Max price for spot instances (default: 0.05)
+  -region str           EC2 region (default: us-west-2)
   -verbosity {1,2,3,4,5}
                         Log level for the logging module (default: 2)
 

--- a/core/manager.py
+++ b/core/manager.py
@@ -22,7 +22,7 @@ class Laniakea(object):
         self.ec2 = None
         self.images = images
 
-    def connect(self, region='us-west-2', **kw_params):
+    def connect(self, region, **kw_params):
         """Connect to a EC2.
 
         :param region: The name of the region to connect to.

--- a/laniakea.py
+++ b/laniakea.py
@@ -59,6 +59,7 @@ class LaniakeaCommandLine(object):
         o.add_argument('-image-args', metavar='k=v', nargs='+', type=str, help='Custom image arguments')
         o.add_argument('-profile', metavar='str', type=str, default='laniakea', help='AWS profile name in .boto')
         o.add_argument('-max-spot-price', metavar='#', type=float, default=0.05, help='Max price for spot instances')
+        o.add_argument('-region', type=str, default='us-west-2', help='EC2 region')
         o.add_argument('-verbosity', default=2, type=int, choices=range(1, 6, 1),
                        help='Log level for the logging module')
         o.add_argument('-focus', action='store_true', default=False, help=argparse.SUPPRESS)
@@ -147,7 +148,7 @@ class LaniakeaCommandLine(object):
         logging.info('Using Boto configuration profile "%s"', Focus.info(args.profile))
         cluster = Laniakea(images)
         try:
-            cluster.connect(profile_name=args.profile)
+            cluster.connect(profile_name=args.profile, region=args.region)
         except Exception as msg:
             logging.error(msg)
             return 1


### PR DESCRIPTION
Add support for regions other than us-west-2 in EC2. Still defaults to us-west-2 to avoid breaking existing stuff.
