### PR TITLE
Changes to improve cross-region interoperability

### DIFF
--- a/laniakea.py
+++ b/laniakea.py
@@ -60,6 +60,7 @@ class LaniakeaCommandLine(object):
         o.add_argument('-profile', metavar='str', type=str, default='laniakea', help='AWS profile name in .boto')
         o.add_argument('-max-spot-price', metavar='#', type=float, default=0.05, help='Max price for spot instances')
         o.add_argument('-region', type=str, default='us-west-2', help='EC2 region')
+        o.add_argument('-zone', type=str, default=None, help='EC2 placement zone')
         o.add_argument('-verbosity', default=2, type=int, choices=list(range(1, 6, 1)),
                        help='Log level for the logging module')
         o.add_argument('-focus', action='store_true', default=False, help=argparse.SUPPRESS)
@@ -160,6 +161,11 @@ class LaniakeaCommandLine(object):
             images[args.image_name].update(args.image_args)
 
         logging.info('Using Boto configuration profile "%s"', Focus.info(args.profile))
+        
+        # If a zone has been specified on the command line, use that for all of our images
+        if args.zone:
+            for image_name in images:
+                images[image_name]['placement'] = args.zone
 
         cluster = Laniakea(images)
         try:


### PR DESCRIPTION
The two changes made here are required for cross-region interoperability. When switching the region, the AMI IDs also change, so we need some way to keep the AMI reference consistent across regions (in this case, the AMI name was used and is resolved to the AMI ID at runtime). Also, switching the region with a command line argument does not make sense if there is no command line argument to specify the zone/placement of the instance. In order to pick the lowest spot prices, choosing the right zone within a region is crucial and we shouldn't make configurations for all combinations of zones/regions, duplicating a lot of other configuration data.
