### PR TITLE
Add macro: `@!all_macros_docker@` 

### DIFF
--- a/laniakea/__init__.py
+++ b/laniakea/__init__.py
@@ -125,6 +125,13 @@ class LaniakeaCommandLine(object):
                 macro_var_exports = "\n".join(macro_var_export_list)
 
                 userdata = userdata.replace('@%s@' % macro_var, macro_var_exports)
+            elif macro_var == "!all_macros_docker":
+                macro_var_export_list = []
+                for defined_macro in macros:
+                    macro_var_export_list.append("-e '%s=%s'" % (defined_macro, macros[defined_macro]))
+                macro_var_exports = " ".join(macro_var_export_list)
+
+                userdata = userdata.replace('@%s@' % macro_var, macro_var_exports)
             elif macro_var not in macros:
                 logger.error('Undefined variable @%s@ in UserData script', macro_var)
                 return

--- a/tests/test_userdata_macros.py
+++ b/tests/test_userdata_macros.py
@@ -69,6 +69,27 @@ export BAZ='BAZVAL'
 """
 
 
+userdata_test_macro_docker = """
+#!/bin/bash
+
+# This is a sample userdata script with macro export to arguments
+
+docker run @!all_macros_docker@ image
+
+# End
+"""
+
+userdata_test_macro_docker_expected = """
+#!/bin/bash
+
+# This is a sample userdata script with macro export to arguments
+
+docker run -e 'FOO=FOOVAL' -e 'BAR=BARVAL' -e 'BAZ=BAZVAL' image
+
+# End
+"""
+
+
 class LaniakeaTestMacroReplacement(unittest.TestCase):
     def runTest(self):
         self.assertEqual(LaniakeaCommandLine.handle_tags(userdata_test_macros, test_macros),
@@ -79,3 +100,9 @@ class LaniakeaTestMacroListExport(unittest.TestCase):
     def runTest(self):
         self.assertEqual(LaniakeaCommandLine.handle_tags(userdata_test_macro_export, test_macros),
                          userdata_test_macro_export_expected)
+
+
+class LaniakeaTestMacroListDocker(unittest.TestCase):
+    def runTest(self):
+        self.assertEqual(LaniakeaCommandLine.handle_tags(userdata_test_macro_docker, test_macros),
+                         userdata_test_macro_docker_expected)


### PR DESCRIPTION
This resolves to `-e 'MACRO=value' ...` in the user data, suitable for
exporting macros to a docker invocation or any other sub-process that
uses `-e` for environment exports.