### PR TITLE
Stop calling pip internal APIs to make laniakea work with pip 10.

### DIFF
--- a/laniakea/core/providers/azure/manager.py
+++ b/laniakea/core/providers/azure/manager.py
@@ -9,15 +9,8 @@ import random
 import os.path
 import logging
 
+import azure
 import appdirs
-try:
-    import azure
-except ImportError:
-    import pip
-    try:
-        pip.main(['install', 'azure'])
-    except ValueError as msg:
-        sys.exit("Unable to install azure module")
 
 from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.resource import ResourceManagementClient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 appdirs==1.4.3
+azure==3.0.0
 boto==2.48.0
 pytest


### PR DESCRIPTION
Currently, using Laniakea with pip 10 throws, but works with pip 9.

From [pip 10 release notes](https://pip.pypa.io/en/stable/news/#deprecations-and-removals):

```
Move all of pip's APIs into the pip._internal package, properly reflecting the fact that pip does not currently have any public APIs. (#4696, #4700)
```

This means that from pip 10 onwards, we can no longer call `pip.main` anymore, nor should we rely on it. Instead, we should put the `azure` package requirement into `requirements.txt`.