### PR TITLE
Make the setup process more lightweight (Fix #31)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ branches:
     only:
         - master
 install:
-    - pip install -r requirements.txt
-    - pip install -e .
+    - pip install -e .[all,test]
 script:
     - pytest
 deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-appdirs==1.4.3
-azure==3.0.0
-boto==2.48.0
-pytest

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,18 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import itertools
 from setuptools import setup
 
 from laniakea import LaniakeaCommandLine
+
+
+EXTRAS = {
+    'azure': ['azure-mgmt-resource>=1.2.2'],
+    'ec2': ['boto>=2.48.0']
+}
+EXTRAS['all'] = list(set(itertools.chain.from_iterable(EXTRAS.values())))
+EXTRAS['test'] = ['pytest']
 
 
 if __name__ == '__main__':
@@ -27,16 +36,24 @@ if __name__ == '__main__':
         entry_points={
             "console_scripts": ["laniakea = laniakea:LaniakeaCommandLine.main"]
         },
-        install_requires=['appdirs', 'boto'],
+        extras_require=EXTRAS,
+        install_requires=['appdirs>=1.4.3'],
         license='MPL 2.0',
         maintainer='Christoph Diehl',
         maintainer_email='cdiehl@mozilla.com',
         name='laniakea',
-        packages=['laniakea', 'laniakea.core'],
+        packages=[
+            'laniakea',
+            'laniakea.core',
+            'laniakea.core.providers',
+            'laniakea.core.providers.azure',
+            'laniakea.core.providers.ec2'
+        ],
         package_data={
             'laniakea': [
                 'examples/*',
-                'userdata/*',
+                'userdata/*/*',
+                'userdata/*/*/*',
             ]
         },
         url='https://github.com/MozillaSecurity/laniakea',


### PR DESCRIPTION
* Fix clean installation errors.
* Merge requirements into `setup.py`.
* Use `extras_require` to organize dependencies.
  * azure: requirements for Azure provider.
  * ec2: reqs for AWS EC2 provider.
  * all:  install reqs for all providers.
  * test: reqs for running unittests.
* To get everything (current requirements.txt behavior), use:
  `pip install laniakea[all,test]`
* Work towards #25 only enough that clean installation is possible and
  providers can be imported separately.