### PR TITLE
[GCE] Add terminate_nowait()

### DIFF
--- a/laniakea/core/providers/gce/manager.py
+++ b/laniakea/core/providers/gce/manager.py
@@ -358,6 +358,28 @@ class ComputeEngineManager:
 
         return result
 
+    def terminate_nowait(self, nodes=None):
+        """Destroy one or many nodes, without waiting to see that the node is destroyed.
+
+        :param   nodes: Nodes to be destroyed.
+        :type    nodes: ``list``
+        """
+        if not self.is_connected():
+            return
+
+        nodes = nodes or self.nodes
+
+        try:
+            self.gce.ex_destroy_multiple_nodes(nodes, timeout=0, ignore_errors=False)
+        except Exception as error:  # pylint: disable=broad-except
+            # directly check type since the exception should be exactly `Exception` and not a subclass
+            if type(error) is Exception and "timeout" in str(error).lower():  # pylint: disable=unidiomatic-typecheck
+                # success
+                logging.info('Requested destruction of %d nodes', len(nodes))
+                return
+            raise
+        raise Exception("Call to ex_destroy_multiple_nodes() returned unexpectedly.")
+
     def terminate(self, nodes=None):
         """Destroy one or many nodes.
 


### PR DESCRIPTION
Request instance deletion without waiting for it to complete. The only way to accomplish this is to set timeout=0 which will raise a timeout exception once the request is made but before polling has begun. Then polling can be done externally.